### PR TITLE
fix: add types for dynamic routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -2,8 +2,15 @@
 export const runtime = 'nodejs';
 
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import type { Database } from '@/lib/types';
 
-export default async function ValidatePage({ params }) {
+interface PageParams {
+  params: {
+    id: string;
+  };
+}
+
+export default async function ValidatePage({ params }: PageParams) {
   // Busca o documento correspondente ao ID
   const { data, error } = await supabaseAdmin
     .from('documents')
@@ -20,7 +27,8 @@ export default async function ValidatePage({ params }) {
     );
   }
 
-  const doc = data ?? null;
+  type Document = Database['public']['Tables']['documents']['Row'];
+  const doc = data as Document | null;
 
   if (!doc) {
     return (

--- a/app/validate/[id]/page.tsx
+++ b/app/validate/[id]/page.tsx
@@ -1,27 +1,46 @@
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import Link from 'next/link';
+import type { Database } from '@/lib/types';
 
-export default async function Validate({ params }: { params: { id: string } }){
-  const { data, error } = await supabaseAdmin.from('documents').select('*').eq('id', params.id).maybeSingle();
-  if (error || !data) return <p className="card">Documento não encontrado.</p>;
+type Document = Database['public']['Tables']['documents']['Row'];
+
+export default async function Validate({ params }: { params: { id: string } }) {
+  const { data, error } = await supabaseAdmin
+    .from('documents')
+    .select('*')
+    .eq('id', params.id)
+    .maybeSingle();
+
+  if (error || !data) {
+    return <p className="card">Documento não encontrado.</p>;
+  }
+
+  const doc = data as Document;
+
   return (
     <div className="grid md:grid-cols-2 gap-4">
       <div className="card">
         <h1 className="text-xl font-semibold mb-2">Validação do documento</h1>
         <ul className="text-sm text-slate-600 space-y-1">
-          <li><strong>ID:</strong> {data.id}</li>
-          <li><strong>Status:</strong> {data.status}</li>
-          <li><strong>Assinado em:</strong> {new Date(data.created_at).toLocaleString()}</li>
+          <li><strong>ID:</strong> {doc.id}</li>
+          <li><strong>Status:</strong> {doc.status}</li>
+          <li><strong>Assinado em:</strong> {new Date(doc.created_at).toLocaleString()}</li>
         </ul>
-        {data.signed_pdf_url && (
-          <a className="btn mt-3 inline-block" href={data.signed_pdf_url} target="_blank">Baixar PDF assinado</a>
+        {doc.signed_pdf_url && (
+          <a className="btn mt-3 inline-block" href={doc.signed_pdf_url} target="_blank">
+            Baixar PDF assinado
+          </a>
         )}
       </div>
       <div className="card">
-        <iframe className="w-full h-[70vh] rounded-xl border" src={data.signed_pdf_url || ''}></iframe>
-        <div className="text-xs text-slate-500 mt-2">Se o PDF não abrir, use o botão de download acima.</div>
+        <iframe className="w-full h-[70vh] rounded-xl border" src={doc.signed_pdf_url || ''}></iframe>
+        <div className="text-xs text-slate-500 mt-2">
+          Se o PDF não abrir, use o botão de download acima.
+        </div>
         <div className="mt-3">
-          <Link className="btn" href={`/validate/${params.id}`}>Link público de validação</Link>
+          <Link className="btn" href={`/validate/${params.id}`}>
+            Link público de validação
+          </Link>
         </div>
       </div>
     </div>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
## Summary
- add explicit parameter and document types in dynamic editor page
- type supabase query results in validation page
- ignore node modules and build output

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5ee7202dc832fb9288ac1919d4853