### PR TITLE
fix: address TypeScript build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+dist
+.env
+.env.*
+.vscode
+.DS_Store
+next-env.d.ts

--- a/app/api/sign/route.ts
+++ b/app/api/sign/route.ts
@@ -111,15 +111,16 @@ export async function POST(req: NextRequest) {
     const pubQr = supabaseAdmin.storage.from('signflow').getPublicUrl(`${id}/qr.png`);
 
     // 7) Atualizar registro (payload tipado para evitar 'never')
-    const payload: Database['public']['Tables']['documents']['Update'] = {
+    const payload = {
       signed_pdf_url: pubSigned.data.publicUrl,
       qr_code_url: pubQr.data.publicUrl,
       status: 'signed',
-    };
+    } satisfies Database['public']['Tables']['documents']['Update'];
 
     const upd = await supabaseAdmin
       .from('documents')
-      .update(payload)
+      // Supabase types infer `never` without casting
+      .update(payload as never)
       .eq('id', id);
 
     if (upd.error) {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import type { Database } from '@/lib/types';
 import crypto from 'crypto';
 
 export async function POST(req: NextRequest){
@@ -38,8 +39,8 @@ export async function POST(req: NextRequest){
       userId = u?.user?.id || null;
     }
 
-    // cria registro do documento
-    const { error: errDoc } = await supabaseAdmin.from('documents').insert({
+    // cria registro do documento (payload tipado)
+    const insertPayload = {
       id,
       user_id: userId,
       original_pdf_name,
@@ -49,8 +50,12 @@ export async function POST(req: NextRequest){
       expires_at: new Date(Date.now()+7*24*3600*1000).toISOString(),
       signed_pdf_url: null,
       qr_code_url: null,
-      ip_hash
-    });
+      ip_hash,
+    } satisfies Database['public']['Tables']['documents']['Insert'];
+
+    const { error: errDoc } = await supabaseAdmin
+      .from('documents')
+      .insert(insertPayload as never);
     if (errDoc) throw errDoc;
 
     // salva arquivos no Storage (bucket: 'signflow')

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -1,13 +1,21 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ChangeEvent } from 'react';
 import PdfEditor from '@/components/PdfEditor';
 import { Card, Input, Label } from '@/components/Ui';
 import { createClient } from '@supabase/supabase-js';
 
+type Position = {
+  page: number;
+  nx: number;
+  ny: number;
+  scale: number;
+  rotation: number;
+};
+
 export default function Editor({ params }: { params: { id: string } }){
   const [pdf, setPdf] = useState<File|null>(null);
   const [sig, setSig] = useState<File|null>(null);
-  const [positions, setPositions] = useState<any[]>([]);
+  const [positions, setPositions] = useState<Position[]>([]);
   const [saving, setSaving] = useState(false);
   const [name, setName] = useState('');
 
@@ -42,11 +50,23 @@ export default function Editor({ params }: { params: { id: string } }){
         <div className="grid md:grid-cols-2 gap-3">
           <div>
             <Label>PDF</Label>
-            <Input type="file" accept="application/pdf" onChange={e=>setPdf(e.target.files?.[0]||null)} />
+            <Input
+              type="file"
+              accept="application/pdf"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setPdf(e.target.files?.[0] || null)
+              }
+            />
           </div>
           <div>
             <Label>Assinatura (PNG/JPG)</Label>
-            <Input type="file" accept="image/*" onChange={e=>setSig(e.target.files?.[0]||null)} />
+            <Input
+              type="file"
+              accept="image/*"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setSig(e.target.files?.[0] || null)
+              }
+            />
           </div>
         </div>
         <PdfEditor file={pdf} signature={sig} positions={positions} onPositions={setPositions} />
@@ -54,7 +74,13 @@ export default function Editor({ params }: { params: { id: string } }){
       <Card>
         <div className="space-y-2">
           <Label>Nome do arquivo</Label>
-          <Input value={name} onChange={e=>setName(e.target.value)} placeholder="Contrato.pdf" />
+          <Input
+            value={name}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setName(e.target.value)
+            }
+            placeholder="Contrato.pdf"
+          />
           <button className="btn w-full" onClick={handleUpload} disabled={saving}>Aplicar assinatura + Gerar QR</button>
           <p className="text-xs text-slate-500">O QR será inserido na última página, canto inferior esquerdo.</p>
         </div>

--- a/app/validate/[id]/page.tsx
+++ b/app/validate/[id]/page.tsx
@@ -1,24 +1,29 @@
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import type { Database } from '@/lib/types';
 import Link from 'next/link';
 
 export default async function Validate({ params }: { params: { id: string } }){
-  const { data, error } = await supabaseAdmin.from('documents').select('*').eq('id', params.id).maybeSingle();
-  if (error || !data) return <p className="card">Documento não encontrado.</p>;
+  const { data: doc, error } = await supabaseAdmin
+    .from('documents')
+    .select('*')
+    .eq('id', params.id)
+    .maybeSingle<Database['public']['Tables']['documents']['Row']>();
+  if (error || !doc) return <p className="card">Documento não encontrado.</p>;
   return (
     <div className="grid md:grid-cols-2 gap-4">
       <div className="card">
         <h1 className="text-xl font-semibold mb-2">Validação do documento</h1>
         <ul className="text-sm text-slate-600 space-y-1">
-          <li><strong>ID:</strong> {data.id}</li>
-          <li><strong>Status:</strong> {data.status}</li>
-          <li><strong>Assinado em:</strong> {new Date(data.created_at).toLocaleString()}</li>
+          <li><strong>ID:</strong> {doc.id}</li>
+          <li><strong>Status:</strong> {doc.status}</li>
+          <li><strong>Assinado em:</strong> {new Date(doc.created_at).toLocaleString()}</li>
         </ul>
-        {data.signed_pdf_url && (
-          <a className="btn mt-3 inline-block" href={data.signed_pdf_url} target="_blank">Baixar PDF assinado</a>
+        {doc.signed_pdf_url && (
+          <a className="btn mt-3 inline-block" href={doc.signed_pdf_url} target="_blank">Baixar PDF assinado</a>
         )}
       </div>
       <div className="card">
-        <iframe className="w-full h-[70vh] rounded-xl border" src={data.signed_pdf_url || ''}></iframe>
+        <iframe className="w-full h-[70vh] rounded-xl border" src={doc.signed_pdf_url || ''}></iframe>
         <div className="text-xs text-slate-500 mt-2">Se o PDF não abrir, use o botão de download acima.</div>
         <div className="mt-3">
           <Link className="btn" href={`/validate/${params.id}`}>Link público de validação</Link>


### PR DESCRIPTION
## Summary
- strongly type Supabase `update` and `insert` payloads with `satisfies`
- define `Position` type and typed change handlers in editor
- streamline document fetch in validation page
- ignore development artifacts and document Supabase cast

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE=service npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5e344ec98832f9c952b1f431807d5