### PR TITLE
refactor: Simplifica o carregamento de PDF e corrige a pré-visualização

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -481,7 +481,7 @@ export default function EditorPage() {
           {pdfFile ? (
             <div style={{ border:'1px solid #e5e7eb', borderRadius:12, padding:12, background:'#f8fafc' }}>
               <PdfEditor
-                file={pdfFile}
+                pdfBytes={pdfBytes}
                 signatureUrl={signaturePreviewUrl}
                 positions={positions}
                 onPositions={setPositions}


### PR DESCRIPTION
Esta alteração refatora o componente `PdfEditor` para aceitar um `ArrayBuffer` diretamente, em vez de um objeto `File`. Esta abordagem simplifica o código, remove a lógica de carregamento complexa e resolve o problema de a pré-visualização do PDF não carregar.

As alterações incluem:
- Modificação do `PdfEditor.tsx` para aceitar a `prop` `pdfBytes`.
- Atualização da página `app/editor/page.tsx` para passar o `ArrayBuffer` do PDF.
- Remoção da lógica de carregamento de ficheiros desnecessária do componente `PdfEditor`.