### PR TITLE
Revamp validation UI and extend certificate metadata

### DIFF
--- a/app/appearance/page.tsx
+++ b/app/appearance/page.tsx
@@ -20,6 +20,8 @@ export default function AppearancePage() {
   const [reg, setReg] = useState('Registro (CRM/CRP/OAB/CNPJ)')
   const [logoFile, setLogoFile] = useState<File | null>(null)
   const [logoUrl, setLogoUrl] = useState<string | null>(null)
+  const [certificateType, setCertificateType] = useState('Certificado digital ICP-Brasil')
+  const [certificateValidUntil, setCertificateValidUntil] = useState('')
 
   const [profiles, setProfiles] = useState<Profile[]>([])
   const [info, setInfo] = useState<string | null>(null)
@@ -49,11 +51,21 @@ export default function AppearancePage() {
     try {
       setInfo(null)
       const logo = await uploadLogoIfAny()
-      const theme = { color, footer, issuer, reg, logo_url: logo ?? logoUrl ?? null }
+      const theme = {
+        color,
+        footer,
+        issuer,
+        reg,
+        logo_url: logo ?? logoUrl ?? null,
+        certificate_type: certificateType,
+        certificate_valid_until: certificateValidUntil || null,
+      }
       const { error } = await supabase.from('validation_profiles').insert({ name, type, theme })
       if (error) { setInfo('Erro ao salvar perfil: '+error.message); return }
       setInfo('Perfil criado!')
       setName(''); setLogoFile(null); setLogoUrl(null)
+      setCertificateType('Certificado digital ICP-Brasil')
+      setCertificateValidUntil('')
       const { data } = await supabase.from('validation_profiles').select('id, name, type, theme').order('created_at', { ascending: false })
       setProfiles((data || []) as Profile[])
     } catch { setInfo('Falha ao criar perfil.') }
@@ -82,6 +94,16 @@ export default function AppearancePage() {
             <input type="color" value={color} onChange={e=>setColor(e.target.value)} title="Cor do tema" />
             <input placeholder="Instituição/Profissional" value={issuer} onChange={e=>setIssuer(e.target.value)} style={{ padding:10, border:'1px solid #e5e7eb', borderRadius:8 }} />
             <input placeholder="Registro (CRM/CRP/OAB/CNPJ)" value={reg} onChange={e=>setReg(e.target.value)} style={{ padding:10, border:'1px solid #e5e7eb', borderRadius:8 }} />
+            <input placeholder="Tipo de certificado (ex.: ICP-Brasil A3)" value={certificateType} onChange={e=>setCertificateType(e.target.value)} style={{ padding:10, border:'1px solid #e5e7eb', borderRadius:8 }} />
+            <div>
+              <label style={{ display:'block', fontSize:12, color:'#6b7280', marginBottom:4 }}>Validade do certificado</label>
+              <input
+                type="date"
+                value={certificateValidUntil}
+                onChange={e=>setCertificateValidUntil(e.target.value)}
+                style={{ padding:10, border:'1px solid #e5e7eb', borderRadius:8, width:'100%' }}
+              />
+            </div>
             <textarea placeholder="Rodapé" value={footer} onChange={e=>setFooter(e.target.value)} style={{ padding:10, border:'1px solid #e5e7eb', borderRadius:8 }} />
             <div>
               <div>Logo (opcional):</div>

--- a/app/validate/[id]/page.tsx
+++ b/app/validate/[id]/page.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
+import { Download } from 'lucide-react'
+
 import { supabase } from '@/lib/supabaseClient'
 
 type Doc = {
@@ -64,17 +66,31 @@ export default function ValidatePage() {
   const reg = theme.reg || 'Registro'
   const footer = theme.footer || ''
   const logo = theme.logo_url || null
+  const certificateType = theme.certificate_type || 'Certificado digital (modelo padrão)'
+  const certificateValidUntilRaw = theme.certificate_valid_until || null
+  const certificateValidUntil = useMemo(() => {
+    if (!certificateValidUntilRaw) return null
+    const asDate = new Date(certificateValidUntilRaw)
+    if (!Number.isNaN(asDate.getTime())) {
+      return asDate.toLocaleDateString()
+    }
+    return String(certificateValidUntilRaw)
+  }, [certificateValidUntilRaw])
   const st = (doc.status || '').toLowerCase()
   const isCanceled = st === 'canceled'
 
+  const documentName = doc.original_pdf_name || 'Documento assinado'
+
+  const handleDownload = () => {
+    if (!doc.signed_pdf_url) return
+    window.open(doc.signed_pdf_url, '_blank', 'noopener,noreferrer')
+  }
+
+
   return (
     <div style={{ maxWidth: 900, margin:'24px auto', padding:16 }}>
-      <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom:12 }}>
-        {logo && <img src={logo} alt="logo" style={{ height:48, objectFit:'contain' }} />}
-        <div>
-          <h1 style={{ margin:0, fontSize:22 }}>Validação do Documento</h1>
-          <div style={{ color:'#6b7280', fontSize:12 }}>ID: {doc.id}</div>
-        </div>
+      <div style={{ marginBottom:12 }}>
+        <h1 style={{ margin:0, fontSize:22 }}>Validação do Documento</h1>
       </div>
 
       {isCanceled && (
@@ -84,8 +100,9 @@ export default function ValidatePage() {
         </div>
       )}
 
-      <div style={{ border:`2px solid ${color}`, borderRadius:12, padding:16 }}>
-        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:16 }}>
+      <section style={{ border:`2px solid ${color}`, borderRadius:12, padding:16, marginBottom:16 }}>
+        <h2 style={{ fontSize:18, margin:'0 0 12px 0' }}>Documento</h2>
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(200px, 1fr))', gap:12 }}>
           <div>
             <div style={{ fontSize:12, color:'#6b7280' }}>Status</div>
             <div style={{ fontWeight:700, fontSize:16 }}>{statusPt(doc.status)}</div>
@@ -94,31 +111,111 @@ export default function ValidatePage() {
             <div style={{ fontSize:12, color:'#6b7280' }}>Assinado em</div>
             <div style={{ fontWeight:700, fontSize:16 }}>{new Date(doc.created_at).toLocaleString()}</div>
           </div>
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>Nome do arquivo</div>
+            <div style={{ fontSize:14 }}>{documentName}</div>
+          </div>
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>ID do documento</div>
+            <div style={{ fontFamily:'monospace', fontSize:13, wordBreak:'break-all' }}>{doc.id}</div>
+          </div>
         </div>
 
-        <div style={{ marginTop:12 }}>
-          <div style={{ fontSize:12, color:'#6b7280' }}>Assinatura emitida por</div>
-          <div style={{ fontWeight:600 }}>{issuer}</div>
-          <div style={{ fontSize:14 }}>{reg}</div>
+        <div style={{ marginTop:16 }}>
+          {doc.signed_pdf_url ? (
+            <button
+              type="button"
+              onClick={handleDownload}
+              style={{
+                display:'inline-flex',
+                alignItems:'center',
+                gap:8,
+                backgroundColor: isCanceled ? '#7f1d1d' : color,
+                color:'#fff',
+                border:'none',
+                borderRadius:9999,
+                padding:'10px 18px',
+                fontWeight:600,
+                cursor:'pointer',
+                boxShadow:'0 10px 25px rgba(37,99,235,0.15)'
+              }}
+            >
+              <Download size={18} />
+              {isCanceled ? 'Baixar documento (cancelado)' : 'Baixar documento assinado'}
+            </button>
+          ) : (
+            <div style={{ color:'#6b7280', fontSize:14 }}>PDF assinado ainda não gerado.</div>
+          )}
+        </div>
+      </section>
+
+      <section style={{ border:`2px solid ${color}`, borderRadius:12, padding:16, marginBottom:16 }}>
+        <h2 style={{ fontSize:18, margin:'0 0 12px 0' }}>Signatário</h2>
+        <div style={{ display:'flex', gap:16, flexWrap:'wrap', alignItems:'center' }}>
+          {logo && (
+            <img
+              src={logo}
+              alt="Logo do emissor"
+              style={{ height:56, objectFit:'contain', maxWidth:'100%' }}
+            />
+          )}
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>Assinatura emitida por</div>
+            <div style={{ fontWeight:600 }}>{issuer}</div>
+            <div style={{ fontSize:14 }}>{reg}</div>
+          </div>
         </div>
 
-        <div style={{ display:'flex', gap:16, alignItems:'center', marginTop:16, flexWrap:'wrap' }}>
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(220px, 1fr))', gap:12, marginTop:16 }}>
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>Tipo de certificado</div>
+            <div style={{ fontSize:14 }}>{certificateType}</div>
+          </div>
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>Válido até</div>
+            <div style={{ fontSize:14 }}>{certificateValidUntil ?? 'Validade não informada'}</div>
+          </div>
+        </div>
+      </section>
+
+      <section style={{ border:`2px solid ${color}`, borderRadius:12, padding:16 }}>
+        <h2 style={{ fontSize:18, margin:'0 0 12px 0' }}>Validação rápida</h2>
+        <div style={{ display:'grid', gap:16, gridTemplateColumns:'repeat(auto-fit, minmax(220px, 1fr))', alignItems:'start' }}>
           <div>
             <div style={{ fontSize:12, color:'#6b7280' }}>QR Code</div>
             {doc.qr_code_url ? (
-              <img src={doc.qr_code_url} alt="QR Code" style={{ border:'1px solid #e5e7eb', borderRadius:8, width:160, height:160, objectFit:'contain', filter: isCanceled ? 'grayscale(1)' : 'none' }} />
+              <img
+                src={doc.qr_code_url}
+                alt="QR Code"
+                style={{
+                  border:'1px solid #e5e7eb',
+                  borderRadius:12,
+                  width:'100%',
+                  maxWidth:200,
+                  aspectRatio:'1 / 1',
+                  objectFit:'contain',
+                  filter: isCanceled ? 'grayscale(1)' : 'none'
+                }}
+              />
             ) : <div style={{ color:'#6b7280' }}>Sem QR disponível.</div>}
+            <p style={{ fontSize:12, color:'#6b7280', marginTop:8 }}>
+              Aponte sua câmera ou aplicativo leitor de QR Code para validar este documento diretamente.
+            </p>
           </div>
           <div>
-            <div style={{ fontSize:12, color:'#6b7280' }}>PDF Assinado</div>
-            {doc.signed_pdf_url ? (
-              <a href={doc.signed_pdf_url} target="_blank" style={{ color:isCanceled ? '#7f1d1d' : color, textDecoration:'underline' }}>
-                {isCanceled ? 'Baixar (cancelado)' : 'Baixar PDF'}
-              </a>
-            ) : <div style={{ color:'#6b7280' }}>Ainda não gerado.</div>}
+            <div style={{ fontSize:12, color:'#6b7280' }}>Status da verificação</div>
+            <div style={{ fontSize:14 }}>
+              O documento foi emitido em <strong>{new Date(doc.created_at).toLocaleString()}</strong> e permanece com status
+              {' '}<strong>{statusPt(doc.status)}</strong>.
+            </div>
+            {isCanceled && (
+              <div style={{ color:'#7f1d1d', fontSize:14, marginTop:8 }}>
+                Atenção: este documento foi cancelado. Utilize o QR apenas para auditoria.
+              </div>
+            )}
           </div>
         </div>
-      </div>
+      </section>
 
       <div style={{ marginTop:12, fontSize:12, color:'#374151' }}>
         {footer}

--- a/app/validate/demo/page.tsx
+++ b/app/validate/demo/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import QRCode from 'qrcode'
+import { Download } from 'lucide-react'
 
 export default function ValidateDemoPage() {
   const [qr, setQr] = useState<string | null>(null)
@@ -16,52 +17,126 @@ export default function ValidateDemoPage() {
   const color = '#2563eb'
   const issuer = 'Exemplo: Dr(a). Fulano — CRM/DF 12345'
   const reg = 'Instituição: Hospital/Clínica — CNPJ 00.000.000/0001-00'
+  const certificateType = 'Certificado digital ICP-Brasil A3'
+  const certificateValidUntilRaw = useMemo(() => {
+    const today = new Date()
+    today.setFullYear(today.getFullYear() + 1)
+    return today.toISOString().slice(0, 10)
+  }, [])
+  const certificateValidUntil = useMemo(() => {
+    const asDate = new Date(certificateValidUntilRaw)
+    if (!Number.isNaN(asDate.getTime())) return asDate.toLocaleDateString()
+    return certificateValidUntilRaw
+  }, [certificateValidUntilRaw])
   const footer = 'Demonstração visual da validação no SignFlow (sem consulta ao banco).'
 
   const createdAt = new Date().toLocaleString()
+  const documentName = 'declaração-assinada.pdf'
+
+
+  const handleDownload = () => {
+    alert('No ambiente real, este botão abriria o PDF assinado.')
+  }
 
   return (
     <div style={{ maxWidth: 900, margin: '24px auto', padding: 16 }}>
-      <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom:12 }}>
-        <div>
-          <h1 style={{ margin:0, fontSize:22 }}>Validação — Demo</h1>
-          <div style={{ color:'#6b7280', fontSize:12 }}>ID: demo</div>
-        </div>
+      <div style={{ marginBottom:12 }}>
+        <h1 style={{ margin:0, fontSize:22 }}>Validação — Demo</h1>
       </div>
 
-      <div style={{ border:`2px solid ${color}`, borderRadius:12, padding:16 }}>
-        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:16 }}>
+      <section style={{ border:`2px solid ${color}`, borderRadius:12, padding:16, marginBottom:16 }}>
+        <h2 style={{ fontSize:18, margin:'0 0 12px 0' }}>Documento</h2>
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(200px, 1fr))', gap:12 }}>
           <div>
             <div style={{ fontSize:12, color:'#6b7280' }}>Status</div>
-            <div style={{ fontWeight:700, fontSize:16, color:'#065f46' }}>signed</div>
+            <div style={{ fontWeight:700, fontSize:16, color:'#065f46' }}>Assinado</div>
           </div>
           <div>
             <div style={{ fontSize:12, color:'#6b7280' }}>Assinado em</div>
             <div style={{ fontWeight:700, fontSize:16 }}>{createdAt}</div>
           </div>
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>Nome do arquivo</div>
+            <div style={{ fontSize:14 }}>{documentName}</div>
+          </div>
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>ID do documento</div>
+            <div style={{ fontFamily:'monospace', fontSize:13 }}>demo</div>
+          </div>
         </div>
 
-        <div style={{ marginTop:12 }}>
-          <div style={{ fontSize:12, color:'#6b7280' }}>Assinatura emitida por</div>
-          <div style={{ fontWeight:600 }}>{issuer}</div>
-          <div style={{ fontSize:14 }}>{reg}</div>
+        <div style={{ marginTop:16 }}>
+          <button
+            type="button"
+            onClick={handleDownload}
+            style={{
+              display:'inline-flex',
+              alignItems:'center',
+              gap:8,
+              backgroundColor: color,
+              color:'#fff',
+              border:'none',
+              borderRadius:9999,
+              padding:'10px 18px',
+              fontWeight:600,
+              cursor:'pointer',
+              boxShadow:'0 10px 25px rgba(37,99,235,0.15)'
+            }}
+          >
+            <Download size={18} />
+            Baixar documento assinado
+          </button>
         </div>
+      </section>
 
-        <div style={{ display:'flex', gap:16, alignItems:'center', marginTop:16, flexWrap:'wrap' }}>
+      <section style={{ border:`2px solid ${color}`, borderRadius:12, padding:16, marginBottom:16 }}>
+        <h2 style={{ fontSize:18, margin:'0 0 12px 0' }}>Signatário</h2>
+        <div style={{ fontSize:12, color:'#6b7280' }}>Assinatura emitida por</div>
+        <div style={{ fontWeight:600 }}>{issuer}</div>
+        <div style={{ fontSize:14 }}>{reg}</div>
+
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(220px, 1fr))', gap:12, marginTop:16 }}>
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>Tipo de certificado</div>
+            <div style={{ fontSize:14 }}>{certificateType}</div>
+          </div>
+          <div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>Válido até</div>
+            <div style={{ fontSize:14 }}>{certificateValidUntil}</div>
+          </div>
+        </div>
+      </section>
+
+      <section style={{ border:`2px solid ${color}`, borderRadius:12, padding:16 }}>
+        <h2 style={{ fontSize:18, margin:'0 0 12px 0' }}>Validação rápida</h2>
+        <div style={{ display:'grid', gap:16, gridTemplateColumns:'repeat(auto-fit, minmax(220px, 1fr))', alignItems:'start' }}>
           <div>
             <div style={{ fontSize:12, color:'#6b7280' }}>QR Code (demo)</div>
             {qr ? (
-              <img src={qr} alt="QR Demo" style={{ border:'1px solid #e5e7eb', borderRadius:8, width:160, height:160, objectFit:'contain' }} />
+              <img
+                src={qr}
+                alt="QR Demo"
+                style={{ border:'1px solid #e5e7eb', borderRadius:12, width:'100%', maxWidth:200, aspectRatio:'1 / 1', objectFit:'contain' }}
+              />
             ) : (
               <div style={{ color:'#6b7280' }}>Gerando QR…</div>
             )}
+            <p style={{ fontSize:12, color:'#6b7280', marginTop:8 }}>
+              Aponte sua câmera ou aplicativo leitor de QR Code para validar este documento diretamente.
+            </p>
           </div>
           <div>
-            <div style={{ fontSize:12, color:'#6b7280' }}>PDF Assinado</div>
-            <div style={{ color:'#6b7280' }}>Exemplo — gere um PDF assinado em <a href="/editor" style={{ textDecoration:'underline' }}>/editor</a>.</div>
+            <div style={{ fontSize:12, color:'#6b7280' }}>Status da verificação</div>
+            <div style={{ fontSize:14 }}>
+              O documento foi emitido em <strong>{createdAt}</strong> e permanece com status <strong>Assinado</strong>.
+            </div>
+            <div style={{ fontSize:14, color:'#6b7280', marginTop:8 }}>
+              Utilize o QR Code acima ou acesse o editor para gerar seu próprio PDF assinado em
+              {' '}<a href="/editor" style={{ color:color, textDecoration:'underline' }}>/editor</a>.
+            </div>
           </div>
         </div>
-      </div>
+      </section>
 
       <div style={{ marginTop:12, fontSize:12, color:'#374151' }}>
         {footer}


### PR DESCRIPTION
## Summary
- reorganize the validation page into document, signatário, and validação rápida sections with a primary download CTA, QR caption, and certificate details
- add controlled certificate type and expiration fields to the appearance profile form and persist them in Supabase themes
- refresh the demo validation screen to mirror the new structure and messaging

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68fe966a71a0832f86edcdc6f320742b