### PR TITLE
Handle missing Supabase configuration gracefully

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -6,6 +6,7 @@ import { supabase } from '@/lib/supabaseClient'
 
 export default function LoginPage() {
   const router = useRouter()
+  const supabaseClient = supabase
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -15,7 +16,12 @@ export default function LoginPage() {
   const loginComSenha = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null); setInfo(null); setLoading(true)
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (!supabaseClient) {
+      setError('Serviço de autenticação indisponível. Configure NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.')
+      setLoading(false)
+      return
+    }
+    const { error } = await supabaseClient.auth.signInWithPassword({ email, password })
     setLoading(false)
     if (error) { setError(error.message); return }
     router.replace('/dashboard')
@@ -23,13 +29,27 @@ export default function LoginPage() {
 
   const loginComLink = async () => {
     setError(null); setInfo(null); setLoading(true)
-    const { error } = await supabase.auth.signInWithOtp({
+    if (!supabaseClient) {
+      setError('Serviço de autenticação indisponível. Configure NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.')
+      setLoading(false)
+      return
+    }
+    const { error } = await supabaseClient.auth.signInWithOtp({
       email,
       options: { emailRedirectTo: `${window.location.origin}/auth/callback` }
     })
     setLoading(false)
     if (error) { setError(error.message); return }
     setInfo('Enviamos um link de acesso para o seu e-mail. Abra em até 10–60 minutos.')
+  }
+
+  if (!supabaseClient) {
+    return (
+      <div style={{ maxWidth: 360, margin: '40px auto', padding: 16 }}>
+        <h1>Entrar</h1>
+        <p>Serviço de autenticação indisponível. Configure NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.</p>
+      </div>
+    )
   }
 
   return (

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -6,6 +6,7 @@ import { supabase } from '@/lib/supabaseClient'
 
 export default function SignUpPage() {
   const router = useRouter()
+  const supabaseClient = supabase
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -15,11 +16,25 @@ export default function SignUpPage() {
   const cadastrar = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null); setInfo(null); setLoading(true)
-    const { error } = await supabase.auth.signUp({ email, password })
+    if (!supabaseClient) {
+      setError('Serviço de autenticação indisponível. Configure NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.')
+      setLoading(false)
+      return
+    }
+    const { error } = await supabaseClient.auth.signUp({ email, password })
     setLoading(false)
     if (error) { setError(error.message); return }
     setInfo('Cadastro criado! Confirme seu e-mail (se obrigatório) e faça login.')
     setTimeout(() => router.replace('/login'), 1200)
+  }
+
+  if (!supabaseClient) {
+    return (
+      <div style={{ maxWidth: 360, margin: '40px auto', padding: 16 }}>
+        <h1>Cadastrar</h1>
+        <p>Serviço de autenticação indisponível. Configure NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.</p>
+      </div>
+    )
   }
 
   return (

--- a/app/validate/[id]/page.tsx
+++ b/app/validate/[id]/page.tsx
@@ -41,8 +41,10 @@ export default function ValidatePage() {
     (async () => {
       if (id === 'demo') { window.location.replace('/validate/demo'); return }
       if (!isUuid(id)) { setErrorMsg('ID inválido.'); return }
+      if (!supabase) { setErrorMsg('Serviço de validação indisponível no momento.'); return }
+      const client = supabase
 
-      const { data, error } = await supabase
+      const { data, error } = await client
         .from('documents')
         .select('id, status, created_at, signed_pdf_url, qr_code_url, original_pdf_name, validation_theme_snapshot, metadata, canceled_at')
         .eq('id', id).maybeSingle()

--- a/app/validate/page.tsx
+++ b/app/validate/page.tsx
@@ -5,55 +5,84 @@ export const runtime = 'nodejs';
 
 import { createClient } from '@supabase/supabase-js';
 
-async function fetchDoc(id: string) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  const supabase = createClient(url, anon);
+type FetchDocResult =
+  | { status: 'not-found' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; data: { id: string; status: string | null; created_at: string; signed_pdf_url: string | null; qr_code_url: string | null } };
 
-  const { data, error } = await supabase
-    .from('documents')
-    .select('id, status, created_at, signed_pdf_url, qr_code_url')
-    .eq('id', id)
-    .maybeSingle();
+async function fetchDoc(id: string, url: string, anon: string): Promise<FetchDocResult> {
+  try {
+    const supabase = createClient(url, anon);
 
-  if (error || !data) return null;
-  return data as {
-    id: string; status: string | null; created_at: string; signed_pdf_url: string | null; qr_code_url: string | null;
-  };
+    const { data, error } = await supabase
+      .from('documents')
+      .select('id, status, created_at, signed_pdf_url, qr_code_url')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (error) {
+      return { status: 'error', message: error.message };
+    }
+    if (!data) return { status: 'not-found' };
+    return {
+      status: 'success',
+      data: data as {
+        id: string; status: string | null; created_at: string; signed_pdf_url: string | null; qr_code_url: string | null;
+      },
+    };
+  } catch (error) {
+    console.error('[Supabase] Não foi possível consultar o documento.', error);
+    return { status: 'error', message: 'Erro ao consultar documento.' };
+  }
 }
 
 export default async function ValidatePage({ searchParams }: { searchParams: { id?: string } }) {
   const id = searchParams?.id;
-  const data = id ? await fetchDoc(id) : null;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const validationUnavailable = !supabaseUrl || !supabaseAnon;
+  const result = id && supabaseUrl && supabaseAnon ? await fetchDoc(id, supabaseUrl, supabaseAnon) : null;
+  const doc = result?.status === 'success' ? result.data : null;
+  const lookupError = result?.status === 'error' ? result.message : null;
 
   return (
     <div className="max-w-2xl">
       <h1 className="text-2xl font-semibold mb-2">Validação do documento</h1>
-      {!id && <p className="text-sm text-red-600">Parâmetro ?id ausente.</p>}
-      {id && !data && <p className="text-sm text-red-600">Documento não encontrado.</p>}
+      {validationUnavailable && (
+        <p className="text-sm text-red-600">
+          Serviço de validação indisponível. Configure NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.
+        </p>
+      )}
+      {!validationUnavailable && !id && <p className="text-sm text-red-600">Parâmetro ?id ausente.</p>}
+      {!validationUnavailable && id && result?.status === 'not-found' && (
+        <p className="text-sm text-red-600">Documento não encontrado.</p>
+      )}
+      {!validationUnavailable && lookupError && (
+        <p className="text-sm text-red-600">{lookupError}</p>
+      )}
 
-      {data && (
+      {!validationUnavailable && doc && (
         <div className="rounded-lg border p-4 space-y-3">
           <ul className="text-sm text-slate-700 space-y-1">
-            <li><strong>ID:</strong> {data.id}</li>
-            <li><strong>Status:</strong> {data.status ?? '—'}</li>
-            <li><strong>Assinado em:</strong> {new Date(data.created_at).toLocaleString()}</li>
+            <li><strong>ID:</strong> {doc.id}</li>
+            <li><strong>Status:</strong> {doc.status ?? '—'}</li>
+            <li><strong>Assinado em:</strong> {new Date(doc.created_at).toLocaleString()}</li>
           </ul>
 
           <div className="grid md:grid-cols-2 gap-4">
             <div className="rounded-lg border p-3">
               <div className="text-xs text-slate-500 mb-2">QR Code</div>
-              {data.qr_code_url ? (
-                <img src={data.qr_code_url} alt="QR" className="w-40 h-40 object-contain" />
+              {doc.qr_code_url ? (
+                <img src={doc.qr_code_url} alt="QR" className="w-40 h-40 object-contain" />
               ) : (
                 <div className="text-sm text-slate-500">Sem QR disponível.</div>
               )}
             </div>
             <div className="rounded-lg border p-3">
               <div className="text-xs text-slate-500 mb-2">PDF Assinado</div>
-              {data.signed_pdf_url ? (
+              {doc.signed_pdf_url ? (
                 <a className="inline-flex items-center rounded-lg bg-indigo-600 px-3 py-1.5 text-white hover:bg-indigo-700"
-                   href={data.signed_pdf_url} target="_blank">
+                   href={doc.signed_pdf_url} target="_blank">
                   Baixar PDF
                 </a>
               ) : (

--- a/components/AuthCallbackClient.tsx
+++ b/components/AuthCallbackClient.tsx
@@ -34,6 +34,10 @@ export default function AuthCallbackClient() {
           setMsg('Erro ao autenticar: ' + hashErr);
           return;
         }
+        if (!supabase) {
+          setMsg('Serviço de autenticação indisponível. Configure NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.');
+          return;
+        }
         if (access_token && refresh_token) {
           const { error: setErr } = await supabase.auth.setSession({ access_token, refresh_token });
           if (setErr) {
@@ -47,7 +51,7 @@ export default function AuthCallbackClient() {
 
         const code = sp.get('code');
         if (code) {
-          const { error: exErr } = await supabase.auth.exchangeCodeForSession({ code });
+          const { error: exErr } = await supabase.auth.exchangeCodeForSession(code);
           if (exErr) {
             setMsg('Falha ao concluir o login (code): ' + exErr.message);
             return;

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,19 +1,24 @@
 'use client'
 
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL
 const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
+let client: SupabaseClient | null = null
+
 if (!url || !anon) {
-  // Mensagem amigável (não quebra o app)
-  console.error(
+  console.warn(
     '[Supabase] Variáveis ausentes: defina NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY nas Environment Variables (Production).'
   )
+} else {
+  try {
+    client = createClient(url, anon)
+  } catch (error) {
+    console.error('[Supabase] Não foi possível criar o cliente.', error)
+    client = null
+  }
 }
 
 // Exporta o cliente para uso nas páginas/components do lado do cliente
-export const supabase = createClient(
-  url ?? '',     // valores vazios só serão usados se você tentar usar o cliente sem setar envs
-  anon ?? ''
-)
+export const supabase = client

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     "app",
     "components",
     "lib",
+    "types",
     "supabase",
     "styles",
     ".next/types/**/*.ts"

--- a/types/pdfjs.d.ts
+++ b/types/pdfjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'pdfjs-dist/legacy/build/pdf';


### PR DESCRIPTION
## Summary
- create the Supabase client only when required environment variables are present and initialization succeeds
- harden public-facing pages and auth flows to detect a missing backend and surface friendly guidance instead of throwing
- add a pdfjs module declaration and include it in the TypeScript config

## Testing
- npx tsc --noEmit
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fe9e7c1388832fac970504e5fe5873