### PR TITLE
Add static terms and privacy pages

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Política de Privacidade — SignFlow',
+}
+
+export default function PrivacyPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 text-slate-700">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">Política de Privacidade</h1>
+        <p>
+          Tratamos seus dados com segurança e transparência. Utilizamos as informações apenas para
+          oferecer e aprimorar os serviços da SignFlow, seguindo a legislação vigente e as melhores
+          práticas do mercado.
+        </p>
+        <p>
+          Você pode solicitar acesso, correção ou exclusão dos seus dados a qualquer momento. Nosso
+          time está comprometido em garantir seus direitos de privacidade.
+        </p>
+      </header>
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p>
+          Para mais detalhes sobre o tratamento dos seus dados pessoais, entre em contato com o
+          encarregado de proteção de dados pelo canal oficial disponível no painel da plataforma.
+        </p>
+      </section>
+      <Link
+        href="/"
+        className="inline-flex items-center text-sm font-semibold text-brand-600 hover:text-brand-700"
+      >
+        ← Voltar para a página inicial
+      </Link>
+    </div>
+  )
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Termos de Uso — SignFlow',
+}
+
+export default function TermsPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 text-slate-700">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">Termos de Uso</h1>
+        <p>
+          Ao utilizar a SignFlow você concorda com estes termos, incluindo o uso adequado da
+          plataforma, o respeito às leis aplicáveis e a responsabilidade pelas ações realizadas na
+          sua conta.
+        </p>
+        <p>
+          Podemos atualizar estes termos periodicamente para refletir melhorias no serviço ou
+          mudanças regulatórias. Sempre comunicaremos alterações relevantes com antecedência.
+        </p>
+      </header>
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p>
+          Caso tenha dúvidas sobre como utilizamos seus dados ou sobre suas obrigações como
+          usuário, entre em contato com nossa equipe de suporte. Estamos disponíveis para ajudar e
+          esclarecer qualquer ponto.
+        </p>
+      </section>
+      <Link
+        href="/"
+        className="inline-flex items-center text-sm font-semibold text-brand-600 hover:text-brand-700"
+      >
+        ← Voltar para a página inicial
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a dedicated Termos de Uso page rendered as a simple server component with shared layout styling
- add a Política de Privacidade page reusing the same layout and providing a link back to the homepage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68feacd15104832f854547b10ef2be4d