### PR TITLE
Ensure landing page uses global header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,25 +5,6 @@ import Link from 'next/link'
 export default function HomePage() {
   return (
     <main className="pro-root">
-      {/* ===== NAV / HEADER ===== */}
-      <header className="pro-nav">
-        <div className="wrap nav-row">
-          <Link href="/" className="brand" aria-label="SignFlow - página inicial">
-            <span className="glyph">◆</span> <b>SignFlow</b>
-          </Link>
-          <nav className="links" aria-label="Navegação principal">
-            <Link href="/#como-funciona">Como Funciona</Link>
-            <Link href="/#seguranca">Segurança</Link>
-            <Link href="/#precos">Preços</Link>
-            <Link href="/#suporte">Suporte/Ajuda</Link>
-            <Link href="/login">Entrar</Link>
-          </nav>
-          <Link href="/signup" className="btn btn-primary" aria-label="Criar conta">
-            <BoltIcon/> Criar conta
-          </Link>
-        </div>
-      </header>
-
       {/* ===== HERO ===== */}
       <section className="hero" aria-labelledby="hero-title">
         <div className="hero-bg" />

--- a/components/HeaderClient.tsx
+++ b/components/HeaderClient.tsx
@@ -24,6 +24,13 @@ const NAV_LINKS = [
   { href: '/contato', label: 'Contato' },
 ]
 
+const LANDING_LINKS = [
+  { href: '/#como-funciona', label: 'Como Funciona' },
+  { href: '/#seguranca', label: 'Segurança' },
+  { href: '/#precos', label: 'Preços' },
+  { href: '/#suporte', label: 'Suporte/Ajuda' },
+]
+
 export default function HeaderClient() {
   const router = useRouter()
   const pathname = usePathname()
@@ -94,6 +101,14 @@ export default function HeaderClient() {
     router.push(`/login?next=${next}`)
   }, [router, supabase, user])
 
+  const navLinks = useMemo(() => {
+    if (pathname === '/') {
+      return [...LANDING_LINKS, ...NAV_LINKS]
+    }
+
+    return NAV_LINKS
+  }, [pathname])
+
   return (
     <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/80 backdrop-blur">
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 lg:px-6">
@@ -113,8 +128,9 @@ export default function HeaderClient() {
         </div>
 
         <nav aria-label="Principal" className="hidden items-center gap-3 text-sm font-medium text-slate-700 md:flex">
-          {NAV_LINKS.map(link => {
-            const isActive = pathname === link.href || pathname.startsWith(`${link.href}/`)
+          {navLinks.map(link => {
+            const isActive =
+              !link.href.includes('#') && (pathname === link.href || pathname.startsWith(`${link.href}/`))
             return (
               <Link
                 key={link.href}
@@ -131,6 +147,14 @@ export default function HeaderClient() {
         </nav>
 
         <div className="flex items-center gap-3">
+          {!user && pathname === '/' && (
+            <Link
+              href="/signup"
+              className="hidden items-center gap-2 rounded-xl bg-brand-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 md:inline-flex"
+            >
+              Criar conta
+            </Link>
+          )}
           {!authConfigured && (
             <span className="rounded-lg border border-red-200 bg-red-50 px-2 py-1 text-xs font-medium text-red-600">
               Autenticação indisponível
@@ -186,8 +210,9 @@ export default function HeaderClient() {
       {mobileOpen && (
         <nav className="border-t border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700 md:hidden" aria-label="Menu móvel">
           <ul className="flex flex-col gap-2">
-            {NAV_LINKS.map(link => {
-              const isActive = pathname === link.href || pathname.startsWith(`${link.href}/`)
+            {navLinks.map(link => {
+              const isActive =
+                !link.href.includes('#') && (pathname === link.href || pathname.startsWith(`${link.href}/`))
               return (
                 <li key={link.href}>
                   <Link
@@ -202,6 +227,16 @@ export default function HeaderClient() {
                 </li>
               )
             })}
+            {!user && pathname === '/' && (
+              <li>
+                <Link
+                  href="/signup"
+                  className="flex w-full items-center justify-between rounded-lg bg-brand-600 px-3 py-2 text-white transition hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600"
+                >
+                  Criar conta
+                </Link>
+              </li>
+            )}
             <li>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- reuse the shared header on the landing page by removing the duplicate markup
- extend HeaderClient to render landing navigation anchors and signup CTA when visiting /
- keep mobile and desktop menus in sync so only a single navigation bar appears across routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68feacd112a8832fbb3cc00ea1f25106