### PR TITLE
Handle signing event logging failures gracefully

### DIFF
--- a/app/api/sign/route.ts
+++ b/app/api/sign/route.ts
@@ -341,7 +341,11 @@ export async function POST(req: NextRequest) {
         .insert(payload);
 
       if (insEvents.error) {
-        return NextResponse.json({ error: insEvents.error.message }, { status: 500 });
+        console.error(
+          'Failed to persist signing events for document %s: %s',
+          id,
+          insEvents.error.message
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- avoid surfacing a 500 response when inserting document signing events fails by logging the error instead

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68feace6ec80832f855b93846d08bfc3