### PR TITLE
Improve UI component typings

### DIFF
--- a/components/Ui.tsx
+++ b/components/Ui.tsx
@@ -1,15 +1,40 @@
+import type {
+  HTMLAttributes,
+  InputHTMLAttributes,
+  LabelHTMLAttributes,
+} from 'react';
+import { forwardRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 export const cn = (...classes: Array<string | undefined | null | false>) =>
   twMerge(classes.filter(Boolean).join(' '));
 
-export function Card(p: any) {
-  return <div className={cn('card', p.className)}>{p.children}</div>;
-}
-export function Label(p: any) {
-  return <label className={cn('label', p.className)}>{p.children}</label>;
-}
-export function Input(p: any) {
-  const { className, ...rest } = p;
-  return <input {...rest} className={cn('input', className)} />;
-}
+export type CardProps = HTMLAttributes<HTMLDivElement>;
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} {...props} className={cn('card', className)} />
+  ),
+);
+
+Card.displayName = 'Card';
+
+export type LabelProps = LabelHTMLAttributes<HTMLLabelElement>;
+
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label ref={ref} {...props} className={cn('label', className)} />
+  ),
+);
+
+Label.displayName = 'Label';
+
+export type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input ref={ref} {...props} className={cn('input', className)} />
+  ),
+);
+
+Input.displayName = 'Input';


### PR DESCRIPTION
## Summary
- add explicit HTML attribute typings to the shared Card, Label, and Input components
- expose the components as forwardRef wrappers so callers can pass refs and native props safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68feca78eca4832f98213967b852f929