### PR TITLE
Add middleware for HTTPS redirection

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const forwardedProto = request.headers.get('x-forwarded-proto')
+  const isHttpRequest = forwardedProto === 'http' || request.nextUrl.protocol === 'http:'
+  const hostname = request.nextUrl.hostname
+
+  if (isHttpRequest && hostname !== 'localhost' && hostname !== '127.0.0.1') {
+    const url = request.nextUrl.clone()
+    url.protocol = 'https'
+
+    return NextResponse.redirect(url, 308)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: '/:path*',
+}


### PR DESCRIPTION
## Summary
- add middleware to redirect HTTP traffic to HTTPS with a permanent status code
- ensure local development hosts skip redirects while production domains receive HTTPS enforcement

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691e510792f08327b32ea9a3215b7a4e)