### PR TITLE
Add dedicated logo components for landing page testimonials

### DIFF
--- a/app/components/Logos.tsx
+++ b/app/components/Logos.tsx
@@ -1,0 +1,60 @@
+import Image from 'next/image'
+
+type LogoProps = {
+  className?: string
+  priority?: boolean
+}
+
+const baseClass = (className?: string) => ['logo-img', className].filter(Boolean).join(' ')
+
+export function BancoDoBrasilLogo({ className, priority }: LogoProps) {
+  return (
+    <Image
+      src="/logos/banco-do-brasil.svg"
+      alt="Banco do Brasil"
+      width={150}
+      height={50}
+      className={baseClass(className)}
+      priority={priority}
+    />
+  )
+}
+
+export function HospitalEinsteinLogo({ className, priority }: LogoProps) {
+  return (
+    <Image
+      src="/logos/hospital-einstein.svg"
+      alt="Hospital Israelita Albert Einstein"
+      width={150}
+      height={50}
+      className={baseClass(className)}
+      priority={priority}
+    />
+  )
+}
+
+export function MagazineLuizaLogo({ className, priority }: LogoProps) {
+  return (
+    <Image
+      src="/logos/magazine-luiza.svg"
+      alt="Magazine Luiza"
+      width={150}
+      height={50}
+      className={baseClass(className)}
+      priority={priority}
+    />
+  )
+}
+
+export function GovBrLogo({ className, priority }: LogoProps) {
+  return (
+    <Image
+      src="/logos/govbr.svg"
+      alt="Gov.br"
+      width={150}
+      height={50}
+      className={baseClass(className)}
+      priority={priority}
+    />
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,13 @@
 
 import Link from 'next/link'
 
+import {
+  BancoDoBrasilLogo,
+  GovBrLogo,
+  HospitalEinsteinLogo,
+  MagazineLuizaLogo,
+} from './components/Logos'
+
 export default function HomePage() {
   return (
     <main className="pro-root">
@@ -145,19 +152,19 @@ export default function HomePage() {
           <h2 id="testi-title">Quem usa, aprova</h2>
           <div className="grid-3">
             <Quote
-              logo={<BrandLogo variant="bb" compact label="Banco do Brasil"/>}
+              logo={<BancoDoBrasilLogo />}
               text="Automatizamos a assinatura de contratos nacionais mantendo trilha de auditoria alinhada à Dataprev."
               author="Banco do Brasil"
               role="Diretoria de Operações Digitais"
             />
             <Quote
-              logo={<BrandLogo variant="ein" compact label="Hospital Israelita Albert Einstein"/>}
+              logo={<HospitalEinsteinLogo />}
               text="Reduzimos em 67% o tempo de liberação de laudos clínicos com validação pública e QR em todas as páginas."
               author="Hospital Israelita Albert Einstein"
               role="TI Clínica"
             />
             <Quote
-              logo={<BrandLogo variant="mgl" compact label="Magazine Luiza"/>}
+              logo={<MagazineLuizaLogo />}
               text="Escalamos as aprovações de onboarding corporativo com carimbo e cancelamento rastreável em segundos."
               author="Magazine Luiza"
               role="People & Legal Ops"
@@ -294,36 +301,6 @@ function PriceCard({ title, price, bullets, featured, cta }:{
         {bullets.map((b,i)=><li key={i}><CheckIcon/>{b}</li>)}
       </ul>
       <div>{cta}</div>
-    </div>
-  )
-}
-
-/* ===== LOGOS “REAIS” (estilizados/otimizados em SVG) ===== */
-function BrandLogo({ variant, label, compact }:{
-  variant:'bb'|'ein'|'nub'|'mgl'|'dtp'|'gdf';
-  label:string; compact?:boolean
-}) {
-  const map = {
-    bb:  { bg:'#003399', fg:'#FFD400', txt:'BB' },
-    ein: { bg:'#005EB8', fg:'#FFFFFF', txt:'EIN' },
-    nub: { bg:'#8A05BE', fg:'#FFFFFF', txt:'NU' },
-    mgl: { bg:'#00AEEF', fg:'#FFFFFF', txt:'MGLU' },
-    dtp: { bg:'#0B6C4D', fg:'#FFFFFF', txt:'DTP' },
-    gdf: { bg:'#005BAA', fg:'#FFFFFF', txt:'GDF' },
-  }[variant]
-  return (
-    <div
-      className={`logo-chip ${compact?'compact':''}`}
-      role="listitem"
-      aria-label={label}
-      title={label}
-      tabIndex={0}
-    >
-      <svg viewBox="0 0 110 40" className="logo-svg" aria-hidden>
-        <rect x="0" y="0" width="110" height="40" rx="8" fill={map.bg}/>
-        <text x="14" y="26" fontFamily="'Inter', 'Segoe UI', sans-serif" fontSize="18" fontWeight="800" fill={map.fg}>{map.txt}</text>
-      </svg>
-      {!compact && <span className="logo-name">{label}</span>}
     </div>
   )
 }
@@ -567,12 +544,7 @@ const css = `
 .seal-govbr{--seal-accent:#0b5cab;--seal-bg:#e3edff}
 .seal-secure{--seal-accent:#0f172a;--seal-bg:#e6fbea}
 .seal-lgpd{--seal-accent:#2563eb;--seal-bg:#e0ecff}
-.logo-chip{display:flex;gap:10px;align-items:center;justify-content:flex-start;border:1px solid transparent;border-radius:12px;padding:4px 6px;transition:transform .2s ease, box-shadow .24s ease, border-color .2s ease;outline:none;background:rgba(255,255,255,.8)}
-.logo-chip:hover{transform:translateY(-2px) scale(1.01);box-shadow:0 12px 28px rgba(15,23,42,.12);border-color:rgba(0,91,170,.28)}
-.logo-chip:focus-visible{transform:translateY(-2px) scale(1.01);box-shadow:0 0 0 4px var(--ring),0 12px 28px rgba(15,23,42,.12);border-color:var(--primary)}
-.logo-chip.compact .logo-name{display:none}
-.logo-svg{width:110px;height:40px;border-radius:10px;box-shadow:0 10px 24px rgba(15,23,42,.08)}
-.logo-name{font-size:12px;color:#334155}
+.logo-img{display:block;width:150px;height:auto;border-radius:12px;box-shadow:0 10px 24px rgba(15,23,42,.08);background:#fff}
 .compliance{display:flex;gap:10px;flex-wrap:wrap;justify-content:center;margin:18px 0 6px}
 .chip{display:inline-flex;align-items:center;gap:8px;border:1px solid var(--border);border-radius:999px;background:#fff;padding:8px 12px;color:var(--txt)}
 

--- a/public/logos/banco-do-brasil.svg
+++ b/public/logos/banco-do-brasil.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="60" viewBox="0 0 180 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="60" rx="12" fill="#FFDD00"/>
+  <path d="M60 15l30 15-30 15 10 6 30-15-30-18-10-3z" fill="#0A2F73"/>
+  <path d="M90 21l30 15-30 15 10 6 30-15-30-18-10-3z" fill="#0A2F73" opacity="0.9"/>
+  <text x="22" y="34" font-family="'Inter','Segoe UI',sans-serif" font-size="14" font-weight="800" fill="#0A2F73">Banco do Brasil</text>
+</svg>

--- a/public/logos/govbr.svg
+++ b/public/logos/govbr.svg
@@ -1,0 +1,7 @@
+<svg width="180" height="60" viewBox="0 0 180 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="60" rx="12" fill="#E6EEFF"/>
+  <text x="20" y="36" font-family="'Inter','Segoe UI',sans-serif" font-size="28" font-weight="900" fill="#0B5CAB">gov</text>
+  <text x="84" y="36" font-family="'Inter','Segoe UI',sans-serif" font-size="28" font-weight="900" fill="#F7C948">.</text>
+  <text x="100" y="36" font-family="'Inter','Segoe UI',sans-serif" font-size="28" font-weight="900" fill="#2D9C5B">br</text>
+  <rect x="20" y="42" width="60" height="6" rx="3" fill="#0B5CAB" opacity="0.14"/>
+</svg>

--- a/public/logos/hospital-einstein.svg
+++ b/public/logos/hospital-einstein.svg
@@ -1,0 +1,8 @@
+<svg width="180" height="60" viewBox="0 0 180 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="60" rx="12" fill="#E7F0FB"/>
+  <circle cx="40" cy="30" r="18" fill="#0F6CBD"/>
+  <path d="M40 16v28M26 30h28" stroke="#E7F0FB" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M34 22l12 16M46 22L34 38" stroke="#E7F0FB" stroke-width="2.5" stroke-linecap="round"/>
+  <text x="74" y="34" font-family="'Inter','Segoe UI',sans-serif" font-size="15" font-weight="800" fill="#0F2D52">Hospital Israelita</text>
+  <text x="74" y="48" font-family="'Inter','Segoe UI',sans-serif" font-size="12" font-weight="700" fill="#0F6CBD">Albert Einstein</text>
+</svg>

--- a/public/logos/magazine-luiza.svg
+++ b/public/logos/magazine-luiza.svg
@@ -1,0 +1,8 @@
+<svg width="180" height="60" viewBox="0 0 180 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="60" rx="12" fill="#E6F4FF"/>
+  <rect x="18" y="18" width="50" height="8" rx="4" fill="#00AEEF"/>
+  <rect x="18" y="32" width="80" height="8" rx="4" fill="#1D4ED8"/>
+  <rect x="18" y="40" width="36" height="6" rx="3" fill="#F59E0B"/>
+  <text x="84" y="30" font-family="'Inter','Segoe UI',sans-serif" font-size="15" font-weight="800" fill="#0F2D52">magalu</text>
+  <text x="84" y="44" font-family="'Inter','Segoe UI',sans-serif" font-size="12" font-weight="700" fill="#1D4ED8">Magazine Luiza</text>
+</svg>


### PR DESCRIPTION
## Summary
- add dedicated logo components using next/image for featured institutions
- replace placeholder testimonial logos with branded variants and updated styling
- add SVG assets for Banco do Brasil, Hospital Israelita Albert Einstein, Magazine Luiza, and Gov.br

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691e8de2964083278ee1d817f4339fee)