### PR TITLE
Normalize ny origin for signature placement

### DIFF
--- a/app/api/sign/route.ts
+++ b/app/api/sign/route.ts
@@ -219,17 +219,32 @@ export async function POST(req: NextRequest) {
       const pageWidth = page.getWidth();
       const pageHeight = page.getHeight();
 
-      const nx = typeof pos.nx === 'number' ? pos.nx : null;
-      const ny = typeof pos.ny === 'number' ? pos.ny : null;
-      let centerX = typeof pos.x === 'number' ? pos.x : null;
-      let centerY = typeof pos.y === 'number' ? pos.y : null;
+      const pageWidthRef = typeof pos.page_width === 'number' && Number.isFinite(pos.page_width)
+        ? pos.page_width
+        : pageWidth;
+      const pageHeightRef = typeof pos.page_height === 'number' && Number.isFinite(pos.page_height)
+        ? pos.page_height
+        : pageHeight;
 
-      if (centerX === null) {
-        centerX = nx !== null ? nx * pageWidth : pageWidth / 2;
-      }
-      if (centerY === null) {
-        centerY = ny !== null ? pageHeight - ny * pageHeight : pageHeight / 2;
-      }
+      const nx =
+        typeof pos.nx === 'number' && Number.isFinite(pos.nx)
+          ? Math.max(0, Math.min(1, pos.nx))
+          : typeof pos.x === 'number' && Number.isFinite(pos.x)
+            ? Math.max(0, Math.min(1, pos.x / pageWidthRef))
+            : null;
+
+      const ny =
+        typeof pos.ny === 'number' && Number.isFinite(pos.ny)
+          ? Math.max(0, Math.min(1, pos.ny))
+          : typeof pos.y === 'number' && Number.isFinite(pos.y)
+            ? Math.max(0, Math.min(1, pos.y / pageHeightRef))
+            : null;
+
+      const normalizedNx = nx !== null ? nx : 0.5;
+      const normalizedNy = ny !== null ? ny : 0.5;
+
+      const centerX = normalizedNx * pageWidth;
+      const centerY = pageHeight - normalizedNy * pageHeight;
 
       const scale = typeof pos.scale === 'number' ? pos.scale : 1;
       const rotation = typeof pos.rotation === 'number' ? pos.rotation : 0;

--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -658,8 +658,18 @@ export default function EditorPage() {
       const dims = pageSizes[pos.page - 1] ?? pageSizes[0] ?? { width: 595, height: 842 }
       const cw = dims.width
       const ch = dims.height
-      const nx = typeof pos.nx === 'number' ? pos.nx : 0.5
-      const ny = typeof pos.ny === 'number' ? pos.ny : 0.5
+      const nx =
+        typeof pos.nx === 'number' && Number.isFinite(pos.nx)
+          ? Math.max(0, Math.min(1, pos.nx))
+          : typeof pos.x === 'number' && Number.isFinite(pos.x)
+            ? Math.max(0, Math.min(1, pos.x / cw))
+            : 0.5
+      const ny =
+        typeof pos.ny === 'number' && Number.isFinite(pos.ny)
+          ? Math.max(0, Math.min(1, pos.ny))
+          : typeof pos.y === 'number' && Number.isFinite(pos.y)
+            ? Math.max(0, Math.min(1, pos.y / ch))
+            : 0.5
 
       return {
         page: pos.page,


### PR DESCRIPTION
## Summary
- normalize stored signature positions to a single top-origin ny convention in the editor payload
- translate normalized coordinates consistently in the sign API before drawing on PDF pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920e25f9efc8327b275ec1fa6567309)