### PR TITLE
Handle numeric string positions in stored metadata

### DIFF
--- a/lib/validation/documentSchemas.ts
+++ b/lib/validation/documentSchemas.ts
@@ -12,6 +12,25 @@ const optionalTrimmedString = z.preprocess(
 
 const finiteNumber = z.number().finite();
 
+const coerceFiniteNumber = z.preprocess(
+  value => {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+
+      if (trimmed) {
+        const parsed = Number(trimmed);
+
+        if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+          return parsed;
+        }
+      }
+    }
+
+    return value;
+  },
+  finiteNumber
+);
+
 export const documentIdSchema = z.string().uuid();
 
 export const positionSchema = z
@@ -25,6 +44,16 @@ export const positionSchema = z
     rotation: finiteNumber.optional(),
   })
   .passthrough();
+
+const storedPositionSchema = positionSchema.extend({
+  page: coerceFiniteNumber.int().positive().optional().default(1),
+  x: coerceFiniteNumber.optional(),
+  y: coerceFiniteNumber.optional(),
+  nx: coerceFiniteNumber.optional(),
+  ny: coerceFiniteNumber.optional(),
+  scale: coerceFiniteNumber.optional(),
+  rotation: coerceFiniteNumber.optional(),
+});
 
 export const signatureMetaSchema = z
   .object({
@@ -65,12 +94,31 @@ export const metadataSchema = z
   })
   .passthrough();
 
-export const storedMetadataSchema = z.union([
-  metadataSchema,
-  z.array(positionSchema),
-  z.null(),
-  z.undefined(),
-]);
+export const storedMetadataSchema = z.preprocess(
+  value => {
+    if (Array.isArray(value)) {
+      return value.map(pos => (typeof pos === 'object' && pos ? pos : pos));
+    }
+
+    if (value && typeof value === 'object' && 'positions' in (value as any)) {
+      const withPositions: any = value;
+      return {
+        ...withPositions,
+        positions: Array.isArray(withPositions.positions)
+          ? withPositions.positions.map((pos: unknown) => (typeof pos === 'object' && pos ? pos : pos))
+          : withPositions.positions,
+      };
+    }
+
+    return value;
+  },
+  z.union([
+    metadataSchema.extend({ positions: z.array(storedPositionSchema).default([]) }),
+    z.array(storedPositionSchema),
+    z.null(),
+    z.undefined(),
+  ])
+);
 
 export type Position = z.infer<typeof positionSchema>;
 export type Signer = z.infer<typeof signerSchema>;


### PR DESCRIPTION
## Summary
- add number coercion to stored metadata position validation to accept numeric strings
- allow stored metadata positions within objects or arrays to parse legacy documents during signing

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920e5b817548327a397c022bce82009)