### PR TITLE
Add validation access code gating and persistence

### DIFF
--- a/app/api/validate/[id]/route.ts
+++ b/app/api/validate/[id]/route.ts
@@ -1,0 +1,152 @@
+// app/api/validate/[id]/route.ts
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin';
+import { documentIdSchema, storedMetadataSchema, Metadata, Position } from '@/lib/validation/documentSchemas';
+
+type ValidationPayload = {
+  requires_code: boolean;
+  document?: Record<string, unknown>;
+  events?: Record<string, unknown>[];
+};
+
+const DOC_SELECT =
+  'id, status, created_at, signed_pdf_url, qr_code_url, original_pdf_name, validation_theme_snapshot, metadata, canceled_at';
+
+const sanitizeMetadata = (metadata: Metadata | null) => {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return metadata;
+  }
+  const { validation_access_code: _ignored, ...rest } = metadata as Metadata & {
+    validation_access_code?: string | null;
+  };
+  return rest;
+};
+
+const normalizeMetadata = (rawMetadata: unknown): Metadata | null => {
+  const parsed = storedMetadataSchema.safeParse(rawMetadata);
+  if (!parsed.success) return null;
+  if (Array.isArray(parsed.data)) {
+    return { positions: parsed.data as Position[] };
+  }
+  return (parsed.data as Metadata) || null;
+};
+
+const getValidationConfig = (metadata: Metadata | null) => {
+  const requiresCode = metadata?.validation_requires_code === true;
+  const accessCodeRaw = (metadata as any)?.validation_access_code;
+  const accessCode =
+    typeof accessCodeRaw === 'string' && accessCodeRaw.trim()
+      ? accessCodeRaw.trim()
+      : null;
+  return { requiresCode, accessCode };
+};
+
+const buildResponse = (payload: ValidationPayload) => NextResponse.json(payload, { status: 200 });
+
+export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  const idResult = documentIdSchema.safeParse(params.id);
+  if (!idResult.success) {
+    return NextResponse.json({ error: 'id inválido' }, { status: 400 });
+  }
+
+  const supabaseAdmin = getSupabaseAdmin();
+  const docRes = await supabaseAdmin
+    .from('documents')
+    .select(DOC_SELECT)
+    .eq('id', idResult.data)
+    .maybeSingle();
+
+  if (docRes.error) {
+    return NextResponse.json({ error: docRes.error.message }, { status: 500 });
+  }
+  if (!docRes.data) {
+    return NextResponse.json({ error: 'Documento não encontrado' }, { status: 404 });
+  }
+
+  const metadata = normalizeMetadata(docRes.data.metadata);
+  const { requiresCode } = getValidationConfig(metadata);
+
+  if (requiresCode) {
+    return buildResponse({ requires_code: true });
+  }
+
+  const docPayload = {
+    ...docRes.data,
+    metadata: sanitizeMetadata(metadata),
+  };
+
+  const eventsRes = await supabaseAdmin
+    .from('document_signing_events')
+    .select('id, document_id, signer_name, signer_reg, certificate_type, certificate_issuer, signer_email, signed_at, certificate_valid_until, logo_url, metadata')
+    .eq('document_id', idResult.data)
+    .order('signed_at', { ascending: true });
+
+  if (eventsRes.error) {
+    return NextResponse.json({ error: eventsRes.error.message }, { status: 500 });
+  }
+
+  return buildResponse({
+    requires_code: false,
+    document: docPayload,
+    events: eventsRes.data || [],
+  });
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const idResult = documentIdSchema.safeParse(params.id);
+  if (!idResult.success) {
+    return NextResponse.json({ error: 'id inválido' }, { status: 400 });
+  }
+
+  let body: { code?: string } = {};
+  try {
+    body = (await req.json()) as { code?: string };
+  } catch {
+    return NextResponse.json({ error: 'JSON inválido' }, { status: 400 });
+  }
+
+  const supabaseAdmin = getSupabaseAdmin();
+  const docRes = await supabaseAdmin
+    .from('documents')
+    .select(DOC_SELECT)
+    .eq('id', idResult.data)
+    .maybeSingle();
+
+  if (docRes.error) {
+    return NextResponse.json({ error: docRes.error.message }, { status: 500 });
+  }
+  if (!docRes.data) {
+    return NextResponse.json({ error: 'Documento não encontrado' }, { status: 404 });
+  }
+
+  const metadata = normalizeMetadata(docRes.data.metadata);
+  const { requiresCode, accessCode } = getValidationConfig(metadata);
+
+  const normalizedCode = typeof body.code === 'string' ? body.code.trim() : '';
+  if (requiresCode && (!accessCode || normalizedCode.toUpperCase() !== accessCode.toUpperCase())) {
+    return NextResponse.json({ error: 'Código inválido' }, { status: 403 });
+  }
+
+  const docPayload = {
+    ...docRes.data,
+    metadata: sanitizeMetadata(metadata),
+  };
+
+  const eventsRes = await supabaseAdmin
+    .from('document_signing_events')
+    .select('id, document_id, signer_name, signer_reg, certificate_type, certificate_issuer, signer_email, signed_at, certificate_valid_until, logo_url, metadata')
+    .eq('document_id', idResult.data)
+    .order('signed_at', { ascending: true });
+
+  if (eventsRes.error) {
+    return NextResponse.json({ error: eventsRes.error.message }, { status: 500 });
+  }
+
+  return buildResponse({
+    requires_code: false,
+    document: docPayload,
+    events: eventsRes.data || [],
+  });
+}

--- a/lib/validation/documentSchemas.ts
+++ b/lib/validation/documentSchemas.ts
@@ -64,6 +64,8 @@ export const metadataSchema = z
     signature_meta: signatureMetaSchema.nullable().optional(),
     validation_theme_snapshot: z.record(z.any()).nullable().optional(),
     validation_profile_id: optionalTrimmedString,
+    validation_requires_code: z.boolean().optional(),
+    validation_access_code: optionalTrimmedString,
     signers: z.array(signerSchema).optional(),
     qr_position: qrPositionSchema.optional(),
     qr_page: qrPageSchema.optional(),


### PR DESCRIPTION
### Motivation

- Allow documents to be protected with a short access code so public validation details can be gated without an immediate DB schema migration. 
- Avoid predictable codes by letting the editor generate or accept a custom code and persist it with the document metadata. 

### Description

- Add `validation_requires_code` and `validation_access_code` to the metadata schema in `lib/validation/documentSchemas.ts`.
- Update editor UI in `app/editor/page.tsx` to let users enable “Exigir código de validação”, enter or auto-generate an access code, and include those fields in the upload `FormData` payload.
- Accept, validate and persist the new fields in `app/api/upload/route.ts` and store them inside the `metadata` object so no immediate DB schema migration is required.
- Change signing flow in `app/api/sign/route.ts` to use the persisted access code (instead of deriving it from the UUID) and only render the “Código de Acesso” text when `validation_requires_code` is active.
- Add a server-side validation API at `app/api/validate/[id]/route.ts` that returns `requires_code: true` when a document is protected and validates submitted codes via `POST`, returning minimal `document`+`events` only after successful validation.
- Gate the public validation UI in `app/validate/[id]/page.tsx` to call the new endpoint, prompt for the access code when required, and avoid exposing the raw `validation_access_code` to clients by sanitizing returned metadata.

### Testing

- Started the dev server with `npm run dev`, which booted successfully and reported the app ready.  
- Tried an automated Playwright screenshot to exercise the editor page, but the navigation failed with `net::ERR_SSL_PROTOCOL_ERROR` (no screenshot produced).  
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69763d5a929483338e69a00aaaed8ad6)