### PR TITLE
Remove 'use client' from TrustBadges to allow Server Component rendering

### DIFF
--- a/app/components/landing/TrustBadges.tsx
+++ b/app/components/landing/TrustBadges.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Shield, Lock, Award, FileCheck } from 'lucide-react'
 import { BancoDoBrasilLogo, MagazineLuizaLogo, HospitalEinsteinLogo, GovBrLogo } from '../Logos'
 


### PR DESCRIPTION
### Motivation
- Corrigir erro na página inicial (#130) e permitir que o componente `TrustBadges` seja um Server Component já que ele não usa hooks/estado; nenhuma skill adicional foi necessária.

### Description
- Removida a diretiva `'use client'` do arquivo `app/components/landing/TrustBadges.tsx` para torná-lo compatível com Server Components, mantendo `app/components/Logos.tsx` inalterado.

### Testing
- Executei `npm run build`, que falhou no ambiente por `next: not found`, então o build não pôde ser verificado localmente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e81b822fc8333974a90ec299595db)