### PR TITLE
Add mobile-web-app-capable metadata to app/layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,9 @@ export const metadata: Metadata = {
     statusBarStyle: 'default',
     title: 'SignFlow'
   },
+  other: {
+    'mobile-web-app-capable': 'yes'
+  },
   formatDetection: {
     telephone: false
   },


### PR DESCRIPTION
### Motivation
- Add `mobile-web-app-capable` meta to enable mobile web app behavior while keeping the existing `appleWebApp` configuration unchanged.

### Description
- Inserted `other: { 'mobile-web-app-capable': 'yes' }` into the `metadata` object in `app/layout.tsx` so Next.js will emit the corresponding `<meta name="mobile-web-app-capable" content="yes">` without modifying the existing `appleWebApp` settings.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e844932e4833397f4fc6d8fa0b5af)