### PR TITLE
Add lucide icon fallbacks and optional typings to landing & status components

### DIFF
--- a/app/components/landing/FeaturesGrid.tsx
+++ b/app/components/landing/FeaturesGrid.tsx
@@ -1,9 +1,14 @@
 'use client'
 
-import { MessageCircle, Scale, FolderKanban, FileText, ShieldCheck, Code } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { MessageCircle, Scale, FolderKanban, FileText, ShieldCheck, Code, Circle } from 'lucide-react'
 
 export default function FeaturesGrid() {
-  const features = [
+  const features: Array<{
+    icon?: LucideIcon
+    title: string
+    description: string
+  }> = [
     {
       icon: MessageCircle,
       title: 'Assinatura via WhatsApp',
@@ -51,24 +56,28 @@ export default function FeaturesGrid() {
         </div>
 
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {features.map((feature, i) => (
-            <div key={i}>
-              <div className="group bg-white rounded-xl p-6 border border-gray-200 hover:border-blue-300 hover:shadow-lg transition-all duration-300 h-full">
-                {/* Icon */}
-                <div className="w-12 h-12 rounded-lg bg-blue-100 flex items-center justify-center mb-4 group-hover:bg-blue-600 group-hover:scale-110 transition-all duration-300">
-                  <feature.icon className="w-6 h-6 text-blue-600 group-hover:text-white transition-colors duration-300" />
-                </div>
+          {features.map((feature, i) => {
+            const Icon = feature.icon ?? Circle
 
-                {/* Content */}
-                <h3 className="text-lg font-bold text-gray-900 mb-2">
-                  {feature.title}
-                </h3>
-                <p className="text-gray-600 leading-relaxed">
-                  {feature.description}
-                </p>
+            return (
+              <div key={i}>
+                <div className="group bg-white rounded-xl p-6 border border-gray-200 hover:border-blue-300 hover:shadow-lg transition-all duration-300 h-full">
+                  {/* Icon */}
+                  <div className="w-12 h-12 rounded-lg bg-blue-100 flex items-center justify-center mb-4 group-hover:bg-blue-600 group-hover:scale-110 transition-all duration-300">
+                    <Icon className="w-6 h-6 text-blue-600 group-hover:text-white transition-colors duration-300" />
+                  </div>
+
+                  {/* Content */}
+                  <h3 className="text-lg font-bold text-gray-900 mb-2">
+                    {feature.title}
+                  </h3>
+                  <p className="text-gray-600 leading-relaxed">
+                    {feature.description}
+                  </p>
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       </div>
     </section>

--- a/app/components/landing/HowItWorks.tsx
+++ b/app/components/landing/HowItWorks.tsx
@@ -1,9 +1,15 @@
 'use client'
 
-import { Upload, Users, Download } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { Upload, Users, Download, Circle } from 'lucide-react'
 
 export default function HowItWorks() {
-  const steps = [
+  const steps: Array<{
+    icon?: LucideIcon
+    title: string
+    description: string
+    color: 'blue' | 'green' | 'purple'
+  }> = [
     {
       icon: Upload,
       title: 'Carregue seu PDF',
@@ -67,6 +73,7 @@ export default function HowItWorks() {
 
           {steps.map((step, i) => {
             const colors = colorClasses[step.color as keyof typeof colorClasses]
+            const Icon = step.icon ?? Circle
             
             return (
               <div key={i}>
@@ -79,7 +86,7 @@ export default function HowItWorks() {
 
                     {/* Icon */}
                     <div className={`w-16 h-16 rounded-2xl ${colors.bg} border-2 ${colors.border} flex items-center justify-center mb-6`}>
-                      <step.icon className={`w-8 h-8 ${colors.icon}`} />
+                      <Icon className={`w-8 h-8 ${colors.icon}`} />
                     </div>
 
                     {/* Content */}

--- a/app/components/landing/TrustBadges.tsx
+++ b/app/components/landing/TrustBadges.tsx
@@ -1,8 +1,9 @@
-import { Shield, Lock, Award, FileCheck } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { Shield, Lock, Award, FileCheck, Circle } from 'lucide-react'
 import { BancoDoBrasilLogo, MagazineLuizaLogo, HospitalEinsteinLogo, GovBrLogo } from '../Logos'
 
 export default function TrustBadges() {
-  const badges = [
+  const badges: Array<{ icon?: LucideIcon; label: string; description: string }> = [
     { icon: Shield, label: 'LGPD', description: 'Conforme à legislação' },
     { icon: Award, label: 'ISO 27001', description: 'Certificação de segurança' },
     { icon: FileCheck, label: 'ICP-Brasil', description: 'Validade jurídica' },
@@ -36,19 +37,23 @@ export default function TrustBadges() {
 
             {/* Security badges */}
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 max-w-4xl mx-auto">
-              {badges.map((badge, i) => (
-                <div key={i}>
-                  <div className="bg-white p-3 sm:p-4 rounded-xl border border-gray-200 hover:border-blue-300 hover:shadow-md transition-all duration-200">
-                    <badge.icon className="w-6 h-6 sm:w-8 sm:h-8 text-blue-600 mx-auto mb-2" />
-                    <div className="font-semibold text-gray-900 text-xs sm:text-sm">
-                      {badge.label}
-                    </div>
-                    <div className="text-xs text-gray-500 mt-1 hidden sm:block">
-                      {badge.description}
+              {badges.map((badge, i) => {
+                const Icon = badge.icon ?? Circle
+
+                return (
+                  <div key={i}>
+                    <div className="bg-white p-3 sm:p-4 rounded-xl border border-gray-200 hover:border-blue-300 hover:shadow-md transition-all duration-200">
+                      <Icon className="w-6 h-6 sm:w-8 sm:h-8 text-blue-600 mx-auto mb-2" />
+                      <div className="font-semibold text-gray-900 text-xs sm:text-sm">
+                        {badge.label}
+                      </div>
+                      <div className="text-xs text-gray-500 mt-1 hidden sm:block">
+                        {badge.description}
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           </div>
         </div>

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, SVGProps } from 'react'
-import { Clock3, Database, Download, ShieldCheck } from 'lucide-react'
+import { Clock3, Database, Download, ShieldCheck, Circle } from 'lucide-react'
 
 export const metadata = {
   title: 'Status e uptime — SignFlow',
@@ -9,7 +9,7 @@ type StatusCard = {
   title: string
   status: string
   description: string
-  icon: ComponentType<SVGProps<SVGSVGElement>>
+  icon?: ComponentType<SVGProps<SVGSVGElement>>
 }
 
 const STATUS_ITEMS: StatusCard[] = [
@@ -44,16 +44,20 @@ export default function StatusPage() {
         </p>
       </header>
       <section className="grid gap-4 md:grid-cols-3">
-        {STATUS_ITEMS.map(item => (
-          <article key={item.title} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-            <div className="flex items-center gap-2 text-sm font-semibold text-slate-900">
-              <item.icon className="h-4 w-4 text-brand-600" aria-hidden />
-              {item.title}
-            </div>
-            <p className="mt-2 text-sm font-medium text-emerald-600">{item.status}</p>
-            <p className="mt-1 text-xs text-slate-500">{item.description}</p>
-          </article>
-        ))}
+        {STATUS_ITEMS.map(item => {
+          const Icon = item.icon ?? Circle
+
+          return (
+            <article key={item.title} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-900">
+                <Icon className="h-4 w-4 text-brand-600" aria-hidden />
+                {item.title}
+              </div>
+              <p className="mt-2 text-sm font-medium text-emerald-600">{item.status}</p>
+              <p className="mt-1 text-xs text-slate-500">{item.description}</p>
+            </article>
+          )
+        })}
       </section>
       <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
         <h2 className="text-xl font-semibold text-slate-900">Manutenções planejadas</h2>


### PR DESCRIPTION
### Motivation
- Vários componentes renderizam ícones dinamicamente (`<step.icon />`, `<badge.icon />`, `<feature.icon />`, `<item.icon />`) e podem crashar se o ícone estiver indefinido ou se houver mismatch com a versão instalada de `lucide-react`.
- Não havia garantia local de que todos os nomes de ícones existiam na instalação atual, então é necessário um fallback em tempo de execução para evitar falhas visuais/erros.
- Também é útil tornar as tipagens de ícone explícitas e opcionais para refletir que o campo pode não estar presente.

### Description
- Importei o tipo `LucideIcon` e o ícone `Circle` de `lucide-react` e adicionei `Circle` como fallback em `app/components/landing/HowItWorks.tsx`, `app/components/landing/TrustBadges.tsx`, `app/components/landing/FeaturesGrid.tsx` e `app/status/page.tsx`.
- Atualizei as definições de listas para usar `icon?: LucideIcon` (e `StatusCard.icon?`) e substituí as renderizações diretas como `<badge.icon />` por um padrão seguro `const Icon = badge.icon ?? Circle` seguido de `<Icon ... />`.
- Pequenas correções de JSX/indentação relacionadas à reestruturação do mapeamento dos arrays para suportar o fallback.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e8533a8e48333b7255070fa494f15)